### PR TITLE
Avoid deprecation warnings in regexes

### DIFF
--- a/Kernel/TidyAll/Plugin/OTRS/DTL/Baselink.pm
+++ b/Kernel/TidyAll/Plugin/OTRS/DTL/Baselink.pm
@@ -31,7 +31,7 @@ sub validate_source {    ## no critic
     for my $Line ( split /\n/, $Code ) {
         $Counter++;
 
-        if ( $Line =~ /<form.+action="\$Env{"Baselink"}"/i ) {
+        if ( $Line =~ /<form.+action="\$Env\{"Baselink"\}"/i ) {
             $ErrorMessage .= __PACKAGE__ . "\n" . <<EOF;
 \$Env{\"Baselink\"} is not allowed in <form>tags. Use \$Env{\"CGIHandle\"}!
 Line $Counter: $Line

--- a/Kernel/TidyAll/Plugin/OTRS/DTL/CGIHandle.pm
+++ b/Kernel/TidyAll/Plugin/OTRS/DTL/CGIHandle.pm
@@ -26,7 +26,7 @@ sub validate_source {    ## no critic
         $Counter++;
 
         # allow IE workaround, e. g. <a href="$Env{"CGIHandle"}/$QData{"Filename"}?Action=...">xxx</a>
-        if ( $Line =~ /<a.+href="\$Env{"CGIHandle"}[^\/](.*)>/ ) {
+        if ( $Line =~ /<a.+href="\$Env\{"CGIHandle"\}[^\/](.*)>/ ) {
             $ErrorMessage .= __PACKAGE__ . "\n" . <<EOF;
 \$Env{\"CGIHandle\"} is not allowed in <a>tags. Use \$Env{\"Baselink\"}!
 Line $Counter: $Line

--- a/Kernel/TidyAll/Plugin/OTRS/DTL/LQData.pm
+++ b/Kernel/TidyAll/Plugin/OTRS/DTL/LQData.pm
@@ -28,11 +28,11 @@ sub validate_source {    ## no critic
 
         # next line if IE behavior need to get ignored
         # see bug#5579 - Spaces in filenames are converted to + characters when downloading in IE.
-        next LINE if $Line =~ /href="\$Env{"CGIHandle"}\/\$QData{"Filename"}?/;
+        next LINE if $Line =~ /href="\$Env\{"CGIHandle"}\/\$QData\{"Filename"\}?/;
 
         # next line if links for agent/customer iface for cockpit is used
         # see bug #6172 - Agent/Customer Interface links to instance broken
-        if ( $Line =~ m{href="\$QData{" (?: (?: Agent | Customer ) Link | Destination ) "}}xms ) {
+        if ( $Line =~ m{href="\$QData\{" (?: (?: Agent | Customer ) Link | Destination ) "\}}xms ) {
             next LINE;
         }
 

--- a/Kernel/TidyAll/Plugin/OTRS/Perl/PodSpelling.pm
+++ b/Kernel/TidyAll/Plugin/OTRS/Perl/PodSpelling.pm
@@ -68,7 +68,7 @@ sub validate_source {    ## no critic
             }
         }
         if ( $FunctionItem && $Line =~ /sub/ ) {
-            if ( $Line =~ /sub (.+) {/ ) {
+            if ( $Line =~ /sub (.+) \{/ ) {
                 $FunctionSub = $1;
                 $FunctionSub =~ s/ //;
                 $SubLine = $Line;

--- a/Kernel/TidyAll/Plugin/OTRS/Perl/SubDeclaration.pm
+++ b/Kernel/TidyAll/Plugin/OTRS/Perl/SubDeclaration.pm
@@ -39,8 +39,8 @@ sub transform_source {    ## no critic
     return $Code if $Self->IsPluginDisabled( Code => $Code );
     return $Code if $Self->IsFrameworkVersionLessThan( 2, 4 );
 
-    if ( $Code =~ m|^sub \s+ \w+ \s* \r?\n { |smx ) {
-        $Code =~ s|^(sub \s+ \w+) \s* \r?\n { |$1 {|smxg;
+    if ( $Code =~ m|^sub \s+ \w+ \s* \r?\n \{ |smx ) {
+        $Code =~ s|^(sub \s+ \w+) \s* \r?\n \{ |$1 {|smxg;
     }
 
     return $Code;


### PR DESCRIPTION
perl 5.22 warns "Unescaped left brace in regex is deprecated, passed through in regex"