### PR TITLE
Update SOPM.xsd

### DIFF
--- a/Kernel/TidyAll/Plugin/OTRS/StaticFiles/XSD/SOPM.xsd
+++ b/Kernel/TidyAll/Plugin/OTRS/StaticFiles/XSD/SOPM.xsd
@@ -25,8 +25,6 @@
 
                 <xs:element ref="ChangeLog" minOccurs="0" maxOccurs="unbounded" />
                 <xs:element ref="OS" minOccurs="0" maxOccurs="unbounded" />
-                <xs:element ref="BuildDate" minOccurs="0" />
-                <xs:element ref="BuildHost" minOccurs="0" />
                 <xs:element ref="Filelist"/>
                 <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="IntroInstall"/>


### PR DESCRIPTION
BuildHost and BuildDate is listed as optional argument on error. But when they are present in the .sopm we receive this error:
TidyAll::Plugin::OTRS::SOPM::RequiredElements
\<BuildDate\> no longer used in .sopms!
\<BuildHost\> no longer used in .sopms!
1 file did not pass tidyall check

As reference, the error (to reproduce, put the IntroInstall before the filelist):
/tmp/Code-TidyAll-6k1v/TTO-Survey.sopm:13: element IntroInstall: Schemas validity error : Element 'IntroInstall': This element is not expected. Expected is one of ( ChangeLog, OS, BuildDate, BuildHost, Filelist ).
/tmp/Code-TidyAll-6k1v/TTO-Survey.sopm fails to validate

1 file did not pass tidyall check