### PR TITLE
Fixed framework version check for patch level version

### DIFF
--- a/Kernel/TidyAll/OTRS.pm
+++ b/Kernel/TidyAll/OTRS.pm
@@ -66,7 +66,7 @@ sub DetermineFrameworkVersionFromDirectory {
             for my $Line (@Content) {
                 if ( $Line =~ m{ <Framework (?: [ ]+ [^<>]* )? > }xms ) {
                     my ( $VersionMajor, $VersionMinor )
-                        = $Line =~ m{ <Framework (?: [ ]+ [^<>]* )? > (\d+) \. (\d+) \. [^<*] <\/Framework> }xms;
+                        = $Line =~ m{ <Framework (?: [ ]+ [^<>]* )? > (\d+) \. (\d+) \. [^<*]+ <\/Framework> }xms;
                     if (
                         $VersionMajor > $FrameworkVersionMajor
                         || (


### PR DESCRIPTION
When using a framework version number with a patch level longer than one character in the SOPM (e. g. 5.0.14), code policy will fail to determine the framework version because the regex only matches for one patch level character (e. g. 5.0.x or 5.0.1).